### PR TITLE
Add match for Runnyeye Citadel

### DIFF
--- a/data/maps/map_keys.ini
+++ b/data/maps/map_keys.ini
@@ -36,6 +36,7 @@ paineel = paineel
 north freeport = freportn
 nagafen's lair = soldungb
 liberated citadel of runnyeye = runnyeye
+runnyeye citadel = runnyeye
 frontier mountains = frontiermtns
 the city of mist = citymist
 west freeport = freportw


### PR DESCRIPTION
[Fri Apr 03 20:40:41 2020] LOADING, PLEASE WAIT...
[Fri Apr 03 20:40:50 2020] You have entered Runnyeye Citadel.

Tested on both P99 Blue and Green.

Don't know if it's ever referred to as "Liberated Citadel of Runnyeye" in the Blue/Green timeline, so I just left that line in.