### PR TITLE
Fix to prevent discord settings dialog staying open

### DIFF
--- a/parsers/discord.py
+++ b/parsers/discord.py
@@ -178,11 +178,8 @@ class Discord(ParserWindow):
         self.content.addWidget(scroll_area, 1)
 
     def show_settings(self):
-        if self.settings_dialog:
-            self.settings_dialog.show()
-            return
-
         self.settings_dialog = QDialog()
+        self.settings_dialog.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
         self.settings_dialog.setWindowTitle('Configure Overlay')
         self.settings_dialog.setMinimumSize(1024, 680)
         self.settings_dialog.setContentsMargins(0, 0, 0, 0)

--- a/parsers/discord.py
+++ b/parsers/discord.py
@@ -211,11 +211,14 @@ class Discord(ParserWindow):
         frame.close()
 
     def _on_get_url(self, url):
-        self.url = url.replace("true", "True")
-        self.overlay.loadFinished.connect(self._applyTweaks)
-        self.overlay.load(QtCore.QUrl(self.url))
-        config.data['discord']['url'] = self.url
-        config.save()
+        try:
+            self.url = url.replace("true", "True")
+            self.overlay.loadFinished.connect(self._applyTweaks)
+            self.overlay.load(QtCore.QUrl(self.url))
+            config.data['discord']['url'] = self.url
+            config.save()
+        except AttributeError:
+            pass
 
     def _skip_stream_button(self, webview):
         skipIntro = (


### PR DESCRIPTION
Fix to prevent discord settings dialog staying open after the window was closed

Adding the WA_DeleteOnClose to the dialog caused it to delete itself after it was closed.

This prevents a bug where the webbrowser was staying open in the background after the dialog closed, which could lead to weird behavior in the desktop discord client due to their webpage sending a continuous auth loop to their application because our webbrowser was still open in the dialog. Deleting the dialog deleted the webview as well which probably frees up memory too afterwords :p