### PR TITLE
Signals and Slots rework for location service refactor

### DIFF
--- a/helpers/location_service.py
+++ b/helpers/location_service.py
@@ -53,10 +53,10 @@ class LocationSharingService(QObject):
     def start(self):
         # Setup Websocket
         self.websocket = QWebSocket()
-        self.websocket.connected.connect(self.connected)
-        self.websocket.error.connect(self.error)
-        self.websocket.disconnected.connect(self.disconnected)
-        self.websocket.textMessageReceived.connect(self.message)
+        self.websocket.connected.connect(self.websocket_connected)
+        self.websocket.error.connect(self.websocket_error)
+        self.websocket.disconnected.connect(self.websocket_disconnected)
+        self.websocket.textMessageReceived.connect(self.websocket_message)
         self.websocket.open(QUrl(self.host))
 
         # Setup signals
@@ -120,19 +120,19 @@ class LocationSharingService(QObject):
         self.zone_name = zone_name
 
     # Websocket Connected - This can be useful for delaying a send until the connection is actually connected.
-    def connected(self):
+    def websocket_connected(self):
         self.websocket.ping()
 
     # Websocket Error
-    def error(self, message):
+    def websocket_error(self, message):
         pass
     
     # Websocket Discconected
-    def disconnected(self):
+    def websocket_disconnected(self):
         pass
 
     # Websocket message handler - handles any incoming messages from the websocket server
-    def message(self, message):
+    def websocket_message(self, message):
         QApplication.instance()._signals["locationsharing"].textMessageReceived.emit(message)
 
     # Parses messages from the websocket server
@@ -209,7 +209,7 @@ class LocationSharingService(QObject):
         # fakemessage["type"] = "state"
         # fakemessage["locations"] = {'field of bone': {'ConfigureYou': {'x': -3535.0, 'y': 2735.0, 'z': 7.85, 'timestamp': datetime.now().isoformat(), 'icon': 'corpse'}}}
         # fakemessage["waypoints"] = {'field of bone': {'ConfigureYou': {'x': -3530.0, 'y': 2735.0, 'z': 7.85, 'timestamp': datetime.now().isoformat(), 'icon': 'corpse'}}}
-        # self.message(json.dumps(fakemessage))
+        # self.websocket_message(json.dumps(fakemessage))
 
     # Shares player death with the websocket server
     def share_death(self, timestamp_string, log_string):

--- a/helpers/location_service.py
+++ b/helpers/location_service.py
@@ -1,5 +1,5 @@
-from json import dumps, loads
 from datetime import datetime
+import json
 
 from PyQt6.QtCore import QObject, QUrl, pyqtSignal
 from PyQt6.QtWidgets import QApplication
@@ -37,8 +37,7 @@ class LocationSharingService(QObject):
             if key != "" and self.group_key != key:
                 self.group_key = key
         else:
-            if self.group_key != config.data["sharing"]["group_key"]:
-                self.group_key = config.data["sharing"]["group_key"]
+            self.group_key = config.data["sharing"]["group_key"]
         
         # Set self.host from config
         self.host = config.data["sharing"]["url"]
@@ -138,7 +137,7 @@ class LocationSharingService(QObject):
 
     # Parses messages from the websocket server
     def parse(self, websocket_message):
-        message = loads(websocket_message)
+        message = json.loads(websocket_message)
         if message["type"] == "state":
             # Only process locations if there is data for our location
             if message.get("locations", False).get(self.zone_name.lower(), False):
@@ -163,7 +162,7 @@ class LocationSharingService(QObject):
                     QApplication.instance()._parsers_dict["maps"]._map.remove_player(player)
 
             # Only process waypoints if there is data for our location
-            if message.get("waypoints", False).get(self.zone_name.lower(), False):
+            if message.get("waypoints", {}).get(self.zone_name.lower(), False):
                 # Iterate through the waypoints in the zone
                 for waypoint in message["waypoints"][self.zone_name.lower()]:
                     w_data = message["waypoints"][self.zone_name.lower()][waypoint]
@@ -203,14 +202,14 @@ class LocationSharingService(QObject):
                 "location": share_payload}
 
         # Send the message
-        self.websocket.sendTextMessage(dumps(message))
+        self.websocket.sendTextMessage(json.dumps(message))
 
         # Below is an example of sending a fake message to verify both adding and removing entries works in field of bone at the cab gates
         # fakemessage = {}
         # fakemessage["type"] = "state"
         # fakemessage["locations"] = {'field of bone': {'ConfigureYou': {'x': -3535.0, 'y': 2735.0, 'z': 7.85, 'timestamp': datetime.now().isoformat(), 'icon': 'corpse'}}}
         # fakemessage["waypoints"] = {'field of bone': {'ConfigureYou': {'x': -3530.0, 'y': 2735.0, 'z': 7.85, 'timestamp': datetime.now().isoformat(), 'icon': 'corpse'}}}
-        # self.message(dumps(fakemessage))
+        # self.message(json.dumps(fakemessage))
 
     # Shares player death with the websocket server
     def share_death(self, timestamp_string, log_string):
@@ -237,4 +236,4 @@ class LocationSharingService(QObject):
                 "location": share_payload}
 
             # Send the message
-            self.websocket.sendTextMessage(dumps(message))
+            self.websocket.sendTextMessage(json.dumps(message))

--- a/helpers/location_service.py
+++ b/helpers/location_service.py
@@ -90,8 +90,7 @@ class LocationSharingService(QObject):
 
     def config_updated(self):
         # Handle performing character name override when saving a new name from settings
-        if config.data["sharing"]["enabled"] and config.data["sharing"]["player_name_override"] and config.data["sharing"]["player_name"] != self.character_name:
-            self.character_name = config.data["sharing"]["player_name"]
+        self.character_name = config.data["sharing"]["player_name"]
 
         # Handle setting groupkey from settings changes and account for discord override
         if config.data["sharing"]["discord_channel"]:
@@ -140,7 +139,7 @@ class LocationSharingService(QObject):
         message = json.loads(websocket_message)
         if message["type"] == "state":
             # Only process locations if there is data for our location
-            if message.get("locations", False).get(self.zone_name.lower(), False):
+            if message.get("locations", {}).get(self.zone_name.lower(), False):
                 # Interate through players in the zone
                 for player in message["locations"][self.zone_name.lower()]:
                     #Process any players that are not us

--- a/helpers/logreader.py
+++ b/helpers/logreader.py
@@ -1,6 +1,6 @@
-import os
 from datetime import datetime
 from glob import glob
+import os
 
 from PyQt6.QtCore import QFileSystemWatcher, pyqtSignal, QObject
 from PyQt6.QtWidgets import QApplication

--- a/helpers/logreader.py
+++ b/helpers/logreader.py
@@ -1,17 +1,22 @@
 import os
-import datetime
+from datetime import datetime
 from glob import glob
 
-from PyQt6.QtCore import QFileSystemWatcher, pyqtSignal
+from PyQt6.QtCore import QFileSystemWatcher, pyqtSignal, QObject
+from PyQt6.QtWidgets import QApplication
 
-from helpers import config
-from helpers import location_service
 from helpers import strip_timestamp
 
+class LogReaderSignals(QObject):
+    new_line = pyqtSignal(object)
+    character_updated = pyqtSignal(str)
+    server_updated = pyqtSignal(str)
+    def __init__(self):
+        super().__init__()
 
 class LogReader(QFileSystemWatcher):
-
-    new_line = pyqtSignal(object)
+    character_name = None
+    server_name = None
 
     def __init__(self, eq_directory):
         super().__init__()
@@ -46,9 +51,13 @@ class LogReader(QFileSystemWatcher):
         if changed_file != self._stats['log_file']:
             self._stats['log_file'] = changed_file
             char_name = os.path.basename(changed_file).split("_")[1]
-            if not config.data['sharing']['player_name_override']:
-                config.data['sharing']['player_name'] = char_name
-                location_service.SIGNALS.config_updated.emit()
+            server_name = os.path.basename(changed_file).split("_")[2][:-4]
+            if server_name != self.server_name:
+                self.server_name = server_name
+                QApplication.instance()._signals["logreader"].server_updated.emit(server_name)
+            if char_name != self.character_name:
+                self.character_name = char_name
+                QApplication.instance()._signals["logreader"].character_updated.emit(char_name)
             with open(self._stats['log_file'], 'rb') as log:
                 log.seek(0, os.SEEK_END)
                 current_end = log.tell()
@@ -64,8 +73,8 @@ class LogReader(QFileSystemWatcher):
                 lines = log.readlines()
                 self._stats['last_read'] = log.tell()
                 for line in lines:
-                    self.new_line.emit((
-                        datetime.datetime.now(),
+                    QApplication.instance()._signals["logreader"].new_line.emit((
+                        datetime.now(),
                         strip_timestamp(line)
                         ))
             except Exception:  # do not read lines if they cause errors

--- a/helpers/settings.py
+++ b/helpers/settings.py
@@ -4,14 +4,17 @@ from PyQt6.QtWidgets import (QCheckBox, QDialog, QFormLayout, QFrame,
                              QHBoxLayout, QLabel, QListWidget, QListWidgetItem,
                              QSpinBox, QStackedWidget, QPushButton,
                              QVBoxLayout, QWidget, QComboBox, QLineEdit,
-                             QMessageBox, QColorDialog)
-from PyQt6.QtCore import Qt
+                             QMessageBox, QColorDialog, QApplication)
+from PyQt6.QtCore import Qt, QObject, pyqtSignal
 from PyQt6.QtGui import QColor
 
 from helpers import config, text_time_to_seconds
-from helpers import location_service
 from parsers.spells import CustomTrigger
 
+class SettingsSignals(QObject):
+    config_updated = pyqtSignal()
+    def __init__(self):
+        super().__init__()
 
 WHATS_THIS_CASTING_WINDOW = """The Casting Window is a range of time in which the spell you are casting will land.
 nParse limits parsing successful casts for the spell to only within that window.  This disables nParse from using other's
@@ -121,11 +124,8 @@ class SettingsWindow(QDialog):
                 hexcolor = hex(widget.currentColor().rgb()).replace('0xff', '#')
                 config.data[key1][key2] = hexcolor
         config.save()
-        self._config_update_triggers()
+        QApplication.instance()._signals["settings"].config_updated.emit()
         self.accept()
-
-    def _config_update_triggers(self):
-        location_service.SIGNALS.config_updated.emit()
 
     def _cancelled(self):
         self._set_values()

--- a/helpers/settings.py
+++ b/helpers/settings.py
@@ -1,12 +1,12 @@
 import functools
 
+from PyQt6.QtCore import Qt, QObject, pyqtSignal
+from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import (QCheckBox, QDialog, QFormLayout, QFrame,
                              QHBoxLayout, QLabel, QListWidget, QListWidgetItem,
                              QSpinBox, QStackedWidget, QPushButton,
                              QVBoxLayout, QWidget, QComboBox, QLineEdit,
                              QMessageBox, QColorDialog, QApplication)
-from PyQt6.QtCore import Qt, QObject, pyqtSignal
-from PyQt6.QtGui import QColor
 
 from helpers import config, text_time_to_seconds
 from parsers.spells import CustomTrigger

--- a/nparse.py
+++ b/nparse.py
@@ -2,18 +2,18 @@
 import os
 import sys
 import webbrowser
-import semver
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QCursor, QFontDatabase, QIcon
 from PyQt6.QtWidgets import QApplication, QFileDialog, QMenu, QSystemTrayIcon
+import semver
 
-import parsers
-from parsers.maps.window import MapsSignals
 from helpers import config, logreader, resource_path, get_version
 from helpers.settings import SettingsWindow, SettingsSignals
 from helpers.logreader import LogReaderSignals
 from helpers.location_service import LocationSharingService, LocationSharingSignals
+import parsers
+from parsers.maps.window import MapsSignals
 
 try:
     import pyi_splash  # noqa

--- a/nparse.py
+++ b/nparse.py
@@ -2,16 +2,18 @@
 import os
 import sys
 import webbrowser
+import semver
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QCursor, QFontDatabase, QIcon
-from PyQt6.QtWidgets import (QApplication, QFileDialog, QMenu, QMessageBox,
-                             QSystemTrayIcon)
-import semver
+from PyQt6.QtWidgets import QApplication, QFileDialog, QMenu, QSystemTrayIcon
 
 import parsers
-from helpers import config, logreader, resource_path, get_version, location_service
-from helpers.settings import SettingsWindow
+from parsers.maps.window import MapsSignals
+from helpers import config, logreader, resource_path, get_version
+from helpers.settings import SettingsWindow, SettingsSignals
+from helpers.logreader import LogReaderSignals
+from helpers.location_service import LocationSharingService, LocationSharingSignals
 
 try:
     import pyi_splash  # noqa
@@ -46,6 +48,17 @@ class NomnsParse(QApplication):
         # Updates
         self._toggled = False
         self._log_reader = None
+
+        # Load Signals
+        self._signals = {}
+        self._signals["logreader"] = LogReaderSignals()
+        self._signals["settings"] = SettingsSignals()
+        self._signals["maps"] = MapsSignals()
+        self._signals["locationsharing"] = LocationSharingSignals()
+
+        # Load Services
+        self._services = {}
+        self._services["locationsharing"] = LocationSharingService()
 
         # Load Parsers
         self._load_parsers()
@@ -103,13 +116,12 @@ class NomnsParse(QApplication):
             else:
                 self._log_reader = logreader.LogReader(
                     config.data['general']['eq_log_dir'])
-                self._log_reader.new_line.connect(self._parse)
+                QApplication.instance()._signals["logreader"].new_line.connect(self._parse)
                 self._toggled = True
         else:
             if self._log_reader:
                 self._log_reader.deleteLater()
                 self._log_reader = None
-            location_service.stop_location_service()
             for parser in self._parsers:
                 try:
                     parser.shutdown()
@@ -192,8 +204,6 @@ class NomnsParse(QApplication):
         elif action == quit_action:
             if self._toggled:
                 self._toggle()
-            else:
-                location_service.stop_location_service()
 
             # save parser geometry
             for parser in self._parsers:

--- a/parsers/maps/window.py
+++ b/parsers/maps/window.py
@@ -1,10 +1,10 @@
 """Map parser for nparse."""
-import datetime
 import re
 
-from PyQt6.QtWidgets import QHBoxLayout, QPushButton
+from PyQt6.QtCore import pyqtSignal, QObject
+from PyQt6.QtWidgets import QHBoxLayout, QPushButton, QApplication
 
-from helpers import config, to_real_xy, ParserWindow, location_service
+from helpers import config, to_real_xy, ParserWindow
 
 from .mapcanvas import MapCanvas
 from .mapclasses import MapPoint
@@ -12,6 +12,14 @@ from .mapdata import MapData
 
 ZONE_MATCHER = re.compile(r"There (is|are) \d+ players? in (?P<zone>.+)\.")
 
+class MapsSignals(QObject):
+    zoning = pyqtSignal()
+    new_zone = pyqtSignal(str)
+    location = pyqtSignal(str, str)
+    death = pyqtSignal(str, str)
+    start_recording = pyqtSignal(str)
+    rename_recording = pyqtSignal(str)
+    stop_recording = pyqtSignal()
 
 class Maps(ParserWindow):
 
@@ -63,106 +71,42 @@ class Maps(ParserWindow):
             self._map.load_map(config.data['maps']['last_zone'])
         else:
             self._map.load_map('west freeport')
-        location_service.start_location_service(self.update_locs)
 
     def parse(self, timestamp, text):
         if text[:23] == 'LOADING, PLEASE WAIT...':
-            pass
+            QApplication.instance()._signals["maps"].zoning.emit()
         elif text[:16] == 'You have entered':
+            QApplication.instance()._signals["maps"].new_zone.emit(text[17:-1])
             self._map.load_map(text[17:-1])
         elif ZONE_MATCHER.match(text):
             new_zone = ZONE_MATCHER.match(text).groupdict()['zone'].lower()
             new_zone = MapData.translate_who_zone(new_zone)
             if new_zone not in (self._map._data.zone.lower(), 'everquest'):
+                QApplication.instance()._signals["maps"].new_zone.emit(new_zone)
                 self._map.load_map(new_zone, keep_loc=True)
         elif text[:16] == 'Your Location is':
+            QApplication.instance()._signals["maps"].location.emit(timestamp.isoformat(), text[17:])
             x, y, z = [float(value) for value in text[17:].strip().split(',')]
             x, y = to_real_xy(x, y)
             self._map.add_player('__you__', timestamp, MapPoint(x=x, y=y, z=z))
             self._map.record_path_loc((x, y, z))
-
-            if location_service.get_location_service_connection().enabled:
-                share_payload = {
-                    'x': x,
-                    'y': y,
-                    'z': z,
-                    'zone': self._map._data.zone,
-                    'player': config.data['sharing']['player_name'],
-                    'timestamp': timestamp.isoformat()
-                }
-                location_service.SIGNALS.send_loc.emit(share_payload)
         elif text[:16] == "start_recording_":
+            QApplication.instance()._signals["maps"].start_recording.emit(text.split()[0][16:])
             recording_name = text.split()[0][16:]
             if recording_name:
                 recording_name = recording_name.replace('_', ' ')
                 self._map.start_path_recording(recording_name)
         elif text[:17] == "rename_recording_":
+            QApplication.instance()._signals["maps"].rename_recording.emit(text.split()[0][17:])
             recording_name = text.split()[0][17:]
             if recording_name:
                 recording_name = recording_name.replace('_', ' ')
                 self._map.rename_path_recording(new_name=recording_name)
         elif text[:14] == "stop_recording":
+            QApplication.instance()._signals["maps"].stop_recording.emit()
             self._map.stop_path_recording()
         elif text[:19] == "You have been slain":
-            if (location_service.get_location_service_connection().enabled and
-                    '__you__' in self._map._data.players):
-                share_payload = {
-                    'x': self._map._data.players['__you__'].location.x,
-                    'y': self._map._data.players['__you__'].location.y,
-                    'z': self._map._data.players['__you__'].location.z,
-                    'zone': self._map._data.zone,
-                    'player': config.data['sharing']['player_name'],
-                    'timestamp': timestamp.isoformat(),
-                    'timeout': 60,
-                    'icon': 'corpse'
-                }
-                location_service.SIGNALS.death.emit(share_payload)
-
-    def update_locs(self, locations, waypoints):
-        print(f"Locations: {locations}")
-        print(f"Waypoints: {waypoints}")
-        for zone in locations:
-            # Check which *map is loaded*, not character zone
-            if zone != self._map._data.zone.lower():
-                continue
-            # Add players in the zone
-            for player in locations[zone]:
-                if player.lower() == config.data['sharing']['player_name'].lower():
-                    print(f"player found: {player} (self)")
-                    continue
-                print(f"player found: {player}")
-                p_data = locations[zone][player]
-                p_timestamp = datetime.datetime.fromisoformat(
-                    p_data.get('timestamp'))
-                p_point = MapPoint(
-                    x=p_data['x'], y=p_data['y'], z=p_data['z'])
-                self._map.add_player(player, p_timestamp, p_point)
-            # Remove players that aren't in the zone
-            players_to_remove = []
-            for player in self._map._data.players:
-                if player not in locations[zone] and player != '__you__':
-                    players_to_remove.append(player)
-            for player in players_to_remove:
-                self._map.remove_player(player)
-        for zone in waypoints:
-            # Check which *map is loaded*, not character zone
-            if zone != self._map._data.zone.lower():
-                continue
-            for waypoint in waypoints[zone]:
-                print("waypoint found: %s" % waypoint)
-                w_data = waypoints[zone][waypoint]
-                w_point = MapPoint(
-                    x=w_data['x'], y=w_data['y'], z=w_data['z'])
-                w_icon = w_data.get('icon')
-                self._map.add_waypoint(waypoint, w_point, w_icon)
-
-            # Remove waypoints that aren't in the zone
-            waypoints_to_remove = []
-            for waypoint in self._map._data.waypoints:
-                if waypoint not in waypoints[zone]:
-                    waypoints_to_remove.append(waypoint)
-            for waypoint in waypoints_to_remove:
-                self._map.remove_waypoint(waypoint)
+            QApplication.instance()._signals["maps"].death.emit(timestamp.isoformat(), text)
 
     # events
     def _toggle_show_poi(self, _):

--- a/parsers/maps/window.py
+++ b/parsers/maps/window.py
@@ -5,7 +5,6 @@ from PyQt6.QtCore import pyqtSignal, QObject
 from PyQt6.QtWidgets import QHBoxLayout, QPushButton, QApplication
 
 from helpers import config, to_real_xy, ParserWindow
-
 from .mapcanvas import MapCanvas
 from .mapclasses import MapPoint
 from .mapdata import MapData

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pyqt6
 websockets
-websocket-client
 colorhash
 pathvalidate
 PyQt6-WebEngine


### PR DESCRIPTION
Refactored the location_service to use QWebsocket - removed global signals - added signals to existing apps

This makes the app shutdown immediately instead of being on a sleep loop if the sharing service thread was not started. This also removes the global signals that were in place for location sharing and moves them to a _signals dict off the main QApplication. I also moved the location sharing to a _services off the main QApplication as well so we can access them easier with QApplication.instance()

Pretty big pull, but check over the changes and let me know.

In location_service.py in the share_location function there is a commented out block for sending a fake location with a loc, i was using this in combination with commenting out the websocket.open() command to verify adding players/waypoints works, and on a live connection you can see them get cleaned up. Mostly useful for my testing while working on it, but we can remove it if we merge this in.