### PR TITLE
Signalsandslots cleanup round 2

### DIFF
--- a/helpers/parser.py
+++ b/helpers/parser.py
@@ -47,8 +47,6 @@ class ParserWindow(QFrame):
         self.setWindowOpacity(config.data[self.name]['opacity'] / 100)
 
     def set_flags(self):
-        self.update_window_opacity()
-        self.update_background_color()
         flags = Qt.WindowType.FramelessWindowHint
         flags |= Qt.WindowType.WindowStaysOnTopHint
         flags |= Qt.WindowType.WindowCloseButtonHint
@@ -56,8 +54,6 @@ class ParserWindow(QFrame):
         if config.data[self.name]['clickthrough']:
             flags |= Qt.WindowType.WindowTransparentForInput
         self.setWindowFlags(flags)
-        if config.data[self.name]['toggled']:
-            self.show()
 
     def _toggle_frame(self):
         current_geometry = self.geometry()
@@ -95,7 +91,6 @@ class ParserWindow(QFrame):
             self.hide()
             config.data[self.name]['toggled'] = False
         else:
-            self.set_flags()
             self.show()
             config.data[self.name]['toggled'] = True
         config.save()

--- a/helpers/settings.py
+++ b/helpers/settings.py
@@ -13,6 +13,8 @@ from parsers.spells import CustomTrigger
 
 class SettingsSignals(QObject):
     config_updated = pyqtSignal()
+    spell_triggers_updated = pyqtSignal()
+
     def __init__(self):
         super().__init__()
 
@@ -502,6 +504,7 @@ class CustomTriggerSettings(QDialog):
                 if x.name != ""
             ]
         config.save()
+        QApplication.instance()._signals['settings'].spell_triggers_updated.emit()
 
     def _add_trigger(self):
         self._triggers.addItem('')

--- a/nparse.py
+++ b/nparse.py
@@ -98,12 +98,6 @@ class NomnsParse(QApplication):
             self._parsers_dict["spells"],
             self._parsers_dict["discord"],
         ]
-        for parser in self._parsers:
-            if parser.name in config.data.keys() and 'geometry' in config.data[parser.name].keys():
-                g = config.data[parser.name]['geometry']
-                parser.setGeometry(g[0], g[1], g[2], g[3])
-            if config.data[parser.name]['toggled']:
-                parser.toggle()
 
     def _toggle(self):
         if not self._toggled:
@@ -187,16 +181,7 @@ class NomnsParse(QApplication):
 
         elif action == settings_action:
             self._settings._set_values()
-            if self._settings.exec():
-                # Update required settings
-                for parser in self._parsers:
-                    parser.set_flags()
-                    parser.settings_updated()
-            # some settings are saved within other settings automatically
-            # force update
-            for parser in self._parsers:
-                if parser.name == "spells":
-                    parser.load_custom_timers()
+            self._settings.exec()
 
         elif action == discord_conf_action:
             self._parsers_dict["discord"].show_settings()

--- a/parsers/discord.py
+++ b/parsers/discord.py
@@ -106,8 +106,7 @@ class Discord(ParserWindow):
         self.url = config.data['discord']['url']
         self._setup_webview()
 
-        if self._window_opacity != config.data.get(self.name, {}).get('opacity', 80):
-            self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
+        self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
         self.setWindowOpacity(self._window_opacity / 100)
 
         self._color = config.data.get(self.name, {}).get('color', '#000000')

--- a/parsers/maps/window.py
+++ b/parsers/maps/window.py
@@ -74,8 +74,7 @@ class Maps(ParserWindow):
         else:
             self._map.load_map('west freeport')
 
-        if self._window_opacity != config.data.get(self.name, {}).get('opacity', 80):
-            self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
+        self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
         self.setWindowOpacity(self._window_opacity / 100)
         self.set_flags()
         if self.name in config.data.keys() and 'geometry' in config.data[self.name].keys():

--- a/parsers/maps/window.py
+++ b/parsers/maps/window.py
@@ -22,8 +22,11 @@ class MapsSignals(QObject):
 
 class Maps(ParserWindow):
 
+    _window_opacity = 80
+
     def __init__(self):
         super().__init__()
+        QApplication.instance()._signals['settings'].config_updated.connect(self.config_updated)
         self.name = 'maps'
         self.setWindowTitle(self.name.title())
         self.set_title(self.name.title())
@@ -70,6 +73,21 @@ class Maps(ParserWindow):
             self._map.load_map(config.data['maps']['last_zone'])
         else:
             self._map.load_map('west freeport')
+
+        if self._window_opacity != config.data.get(self.name, {}).get('opacity', 80):
+            self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
+        self.setWindowOpacity(self._window_opacity / 100)
+        self.set_flags()
+        if self.name in config.data.keys() and 'geometry' in config.data[self.name].keys():
+            g = config.data[self.name]['geometry']
+            self.setGeometry(g[0], g[1], g[2], g[3])
+        if config.data[self.name]['toggled']:
+            self.show()
+
+    def config_updated(self):
+        if self._window_opacity != config.data.get(self.name, {}).get('opacity', 80):
+            self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
+            self.setWindowOpacity(self._window_opacity / 100)
 
     def parse(self, timestamp, text):
         if text[:23] == 'LOADING, PLEASE WAIT...':

--- a/parsers/spells.py
+++ b/parsers/spells.py
@@ -24,8 +24,7 @@ class Spells(ParserWindow):
         self.setWindowTitle(self.name.title())
         self.set_title(self.name.title())
 
-        if self._window_opacity != config.data.get(self.name, {}).get('opacity', 80):
-            self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
+        self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
         self.setWindowOpacity(self._window_opacity / 100)
         self.set_flags()
         if self.name in config.data.keys() and 'geometry' in config.data[self.name].keys():


### PR DESCRIPTION
Cleaned up a lot of the display code, set_flags() was being called multiple times as well as .show() which created some weird ui states when saving settings. But the issue was also noticeable if you looked, you could see the taskbar flicker as the window re showed itself multiple times in succession.

Moved more logic into signals and slots and closer to where it is consumed.