### PR TITLE
Fix for autohide logic not working properly after toggling while the window was shown.

### DIFF
--- a/parsers/discord.py
+++ b/parsers/discord.py
@@ -133,6 +133,8 @@ class Discord(ParserWindow):
         if self.always_on_top != config.data.get(self.name, ()).get('always_on_top', False):
             self.always_on_top = config.data.get(self.name, ()).get('always_on_top', False)
             self.set_flags()
+            if config.data.get(self.name, {}).get('toggled', True):
+                self.show()
 
         if config.data.get(self.name, ()).get('auto_hide_menu', True) == False:
             self.auto_hide_menu = False

--- a/parsers/maps/window.py
+++ b/parsers/maps/window.py
@@ -95,6 +95,8 @@ class Maps(ParserWindow):
         if self.always_on_top != config.data.get(self.name, ()).get('always_on_top', False):
             self.always_on_top = config.data.get(self.name, ()).get('always_on_top', False)
             self.set_flags()
+            if config.data.get(self.name, {}).get('toggled', True):
+                self.show()
 
         if config.data.get(self.name, ()).get('auto_hide_menu', True) == False:
             self.auto_hide_menu = False

--- a/parsers/spells.py
+++ b/parsers/spells.py
@@ -58,6 +58,8 @@ class Spells(ParserWindow):
         if self.always_on_top != config.data.get(self.name, ()).get('always_on_top', False):
             self.always_on_top = config.data.get(self.name, ()).get('always_on_top', False)
             self.set_flags()
+            if config.data.get(self.name, {}).get('toggled', True):
+                self.show()
 
         if config.data.get(self.name, ()).get('auto_hide_menu', True) == False:
             self.auto_hide_menu = False


### PR DESCRIPTION
When we set the windowflags it caused the window to hide. Added logic to check if the window was toggled and if so to call show to redisplay the window after the window flags were changed.