### PR TITLE
Added reconnect logic to the websocket, current is set to retry after 3s

### DIFF
--- a/helpers/location_service.py
+++ b/helpers/location_service.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import json
 
-from PyQt6.QtCore import QObject, QUrl, pyqtSignal
+from PyQt6.QtCore import QObject, QUrl, pyqtSignal, QTimer
 from PyQt6.QtWidgets import QApplication
 from PyQt6.QtWebSockets import QWebSocket
 
@@ -146,7 +146,13 @@ class LocationSharingService(QObject):
     
     # Websocket Discconected
     def websocket_disconnected(self):
-        pass
+        if config.data.get("sharing", {}).get("enabled", False):
+            _ = QTimer().singleShot(3000, self.websocket_reconnect )
+
+    # Websocket reconnect logic
+    def websocket_reconnect(self):
+        if config.data.get("sharing", {}).get("enabled", False):
+            self.websocket.open(QUrl(self.host))
 
     # Websocket message handler - handles any incoming messages from the websocket server
     def websocket_message(self, message):

--- a/helpers/location_service.py
+++ b/helpers/location_service.py
@@ -147,7 +147,8 @@ class LocationSharingService(QObject):
     # Websocket Discconected
     def websocket_disconnected(self):
         if config.data.get("sharing", {}).get("enabled", False):
-            _ = QTimer().singleShot(3000, self.websocket_reconnect )
+            timeout = int(config.data.get("sharing", {}).get("reconnect_delay", 5) * 1000)
+            _ = QTimer().singleShot(timeout, self.websocket_reconnect )
 
     # Websocket reconnect logic
     def websocket_reconnect(self):

--- a/helpers/location_service.py
+++ b/helpers/location_service.py
@@ -147,8 +147,8 @@ class LocationSharingService(QObject):
     # Websocket Discconected
     def websocket_disconnected(self):
         if config.data.get("sharing", {}).get("enabled", False):
-            timeout = int(config.data.get("sharing", {}).get("reconnect_delay", 5) * 1000)
-            _ = QTimer().singleShot(timeout, self.websocket_reconnect )
+            reconnect_delay  = int(config.data.get("sharing", {}).get("reconnect_delay", 5) * 1000)
+            _ = QTimer().singleShot(reconnect_delay , self.websocket_reconnect )
 
     # Websocket reconnect logic
     def websocket_reconnect(self):


### PR DESCRIPTION
Setup a QTimer to fire when the websocket disconnects. After a 3 second delay it will try to open the connection again if the sharing service is still enabled.