### PR TITLE
Parser Window Refactor

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -177,6 +177,10 @@ def verify_settings():
         data['maps'].get('always_on_top', True),
         True
         )
+    data['maps']['frameless'] = get_setting(
+        data['maps'].get('frameless', True),
+        True
+        )
 
     # spells
     data['spells'] = data.get('spells', {})
@@ -258,6 +262,10 @@ def verify_settings():
         data['spells'].get('always_on_top', True),
         True
         )
+    data['spells']['frameless'] = get_setting(
+        data['spells'].get('frameless', True),
+        True
+        )
 
     # discord
     data['discord'] = data.get('discord', {})
@@ -301,6 +309,10 @@ def verify_settings():
         )
     data['discord']['always_on_top'] = get_setting(
         data['discord'].get('always_on_top', True),
+        True
+        )
+    data['discord']['frameless'] = get_setting(
+        data['discord'].get('frameless', True),
         True
         )
 

--- a/helpers/parser.py
+++ b/helpers/parser.py
@@ -29,10 +29,10 @@ class ParserWindow(QWidget):
         self.name = name
 
         # Set vars from config
-        self._always_on_top = config.data.get(self.name, ()).get("always_on_top", True)
-        self._auto_hide_menu = config.data.get(self.name, ()).get("auto_hide_menu", True)
-        self._clickthrough = config.data.get(self.name, ()).get("clickthrough", True)
-        self._frameless = config.data.get(self.name, ()).get("frameless", True)
+        self._always_on_top = config.data.get(self.name, {}).get("always_on_top", True)
+        self._auto_hide_menu = config.data.get(self.name, {}).get("auto_hide_menu", True)
+        self._clickthrough = config.data.get(self.name, {}).get("clickthrough", True)
+        self._frameless = config.data.get(self.name, {}).get("frameless", True)
         self._geometry = config.data.get(self.name, {}).get("geometry", [0,0,200,400])
         self._window_flush = config.data.get("general", {}).get("window_flush", True)
         self._window_opacity = config.data.get(self.name, {}).get("opacity", 80)
@@ -88,9 +88,9 @@ class ParserWindow(QWidget):
     def _parser_settings_config_update_watcher(self):
         requies_redraw = False
 
-        settings_always_on_top = config.data.get(self.name, ()).get("always_on_top", True)
-        settings_auto_hide_menu = config.data.get(self.name, ()).get("auto_hide_menu", True)
-        settings_clickthrough = config.data.get(self.name, ()).get("clickthrough", True)
+        settings_always_on_top = config.data.get(self.name, {}).get("always_on_top", True)
+        settings_auto_hide_menu = config.data.get(self.name, {}).get("auto_hide_menu", True)
+        settings_clickthrough = config.data.get(self.name, {}).get("clickthrough", True)
         settings_window_flush = config.data.get("general", {}).get("window_flush", True)
         settings_window_opacity = config.data.get(self.name, {}).get("opacity", 80)
 

--- a/helpers/parser.py
+++ b/helpers/parser.py
@@ -23,7 +23,13 @@ class ParserWindow(QWidget):
     _window_flush = None
     _window_opacity = 80
 
-    def __init__(self):
+    def __init__(self, **kwargs):
+        if not self.name:
+            self.name = kwargs.get("name", None)
+            if not self.name:
+                raise AttributeError(
+                    "'name' is a required attribute that must be set via **kwargs or in the partent class."
+                )
         super().__init__()
 
         # Set vars from config

--- a/helpers/parser.py
+++ b/helpers/parser.py
@@ -23,10 +23,8 @@ class ParserWindow(QWidget):
     _window_flush = None
     _window_opacity = 80
 
-    def __init__(self, name):
+    def __init__(self):
         super().__init__()
-        # Set Vars from init
-        self.name = name
 
         # Set vars from config
         self._always_on_top = config.data.get(self.name, {}).get("always_on_top", True)

--- a/nparse.py
+++ b/nparse.py
@@ -89,9 +89,9 @@ class NomnsParse(QApplication):
 
     def _load_parsers(self):
         self._parsers_dict = {
-            "maps": parsers.Maps(),
-            "spells": parsers.Spells(),
-            "discord": parsers.Discord(),
+            "maps": parsers.Maps("maps"),
+            "spells": parsers.Spells("spells"),
+            "discord": parsers.Discord("discord"),
         }
         self._parsers = [
             self._parsers_dict["maps"],
@@ -116,11 +116,6 @@ class NomnsParse(QApplication):
             if self._log_reader:
                 self._log_reader.deleteLater()
                 self._log_reader = None
-            for parser in self._parsers:
-                try:
-                    parser.shutdown()
-                except:
-                    print("Failed to shutdown parser: %s" % parser.name)
             self._toggled = False
 
     def _parse(self, new_line):
@@ -132,7 +127,7 @@ class NomnsParse(QApplication):
                     config.data[parser.name]['clickthrough'] = (
                         not config.data[parser.name]['clickthrough'])
                     config.save()
-                    parser.set_flags()
+                    parser._set_flags()
                 elif text.startswith('toggle_%s' % parser.name):
                     parser.toggle()
                 elif config.data[parser.name]['toggled'] or parser.name == 'maps':
@@ -189,14 +184,6 @@ class NomnsParse(QApplication):
         elif action == quit_action:
             if self._toggled:
                 self._toggle()
-
-            # save parser geometry
-            for parser in self._parsers:
-                g = parser.geometry()
-                config.data[parser.name]['geometry'] = [
-                    g.x(), g.y(), g.width(), g.height()
-                ]
-            config.save()
 
             self._system_tray.setVisible(False)
             config.APP_EXIT = True

--- a/nparse.py
+++ b/nparse.py
@@ -89,9 +89,9 @@ class NomnsParse(QApplication):
 
     def _load_parsers(self):
         self._parsers_dict = {
-            "maps": parsers.Maps("maps"),
-            "spells": parsers.Spells("spells"),
-            "discord": parsers.Discord("discord"),
+            "maps": parsers.Maps(),
+            "spells": parsers.Spells(),
+            "discord": parsers.Discord(),
         }
         self._parsers = [
             self._parsers_dict["maps"],

--- a/parsers/discord.py
+++ b/parsers/discord.py
@@ -92,12 +92,9 @@ class Discord(ParserWindow):
     _color = ''
     _bg_opacity = 25
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, name):
+        super().__init__(name)
         QApplication.instance()._signals['settings'].config_updated.connect(self.config_updated)
-        self.name = 'discord'
-        self.setWindowTitle(self.name.title())
-        self.set_title(self.name.title())
         self.setAttribute(
             QtCore.Qt.WidgetAttribute.WA_TranslucentBackground, True)
         self.setMinimumWidth(125)
@@ -106,42 +103,14 @@ class Discord(ParserWindow):
         self.url = config.data['discord']['url']
         self._setup_webview()
 
-        self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
-        self.setWindowOpacity(self._window_opacity / 100)
-
         self._color = config.data.get(self.name, {}).get('color', '#000000')
         self._bg_opacity = config.data.get(self.name, {}).get('bg_opacity', '25')
 
         self.update_background_color()
-        if config.data.get(self.name, ()).get('auto_hide_menu', True) == False:
-            self.auto_hide_menu = False
-            self._menu.setVisible(True)
-        self.always_on_top = config.data.get(self.name, ()).get('always_on_top', True)
-        self.set_flags()
-        if self.name in config.data.keys() and 'geometry' in config.data[self.name].keys():
-            g = config.data[self.name]['geometry']
-            self.setGeometry(g[0], g[1], g[2], g[3])
-
         if config.data[self.name]['toggled']:
             self.show()
 
     def config_updated(self):
-        if self._window_opacity != config.data.get(self.name, {}).get('opacity', 80):
-            self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
-            self.setWindowOpacity(self._window_opacity / 100)
-
-        if self.always_on_top != config.data.get(self.name, ()).get('always_on_top', False):
-            self.always_on_top = config.data.get(self.name, ()).get('always_on_top', False)
-            self.set_flags()
-            if config.data.get(self.name, {}).get('toggled', True):
-                self.show()
-
-        if config.data.get(self.name, ()).get('auto_hide_menu', True) == False:
-            self.auto_hide_menu = False
-            self._menu.setVisible(True)
-        else:
-            self._menu.setVisible(False)
-
         if self._color != config.data.get(self.name, {}).get('color', '#000000'):
             self._color = config.data.get(self.name, {}).get('color', '#000000')
             self._fix_background()
@@ -150,12 +119,6 @@ class Discord(ParserWindow):
         if self._bg_opacity != config.data.get(self.name, {}).get('bg_opacity', 25):
             self._bg_opacity = config.data.get(self.name, {}).get('bg_opacity', 25)
             self._fix_background()
-
-    def shutdown(self):
-        if self.settings_dialog:
-            self.settings_dialog.destroy()
-        if self.overlay:
-            self.overlay.destroy()
 
     def _applyTweaks(self):
         if self.overlay:
@@ -191,10 +154,6 @@ class Discord(ParserWindow):
                 blue=qcolor.blue(),
                 alpha=self._window_opacity / 100
             ))
-
-    def update_window_opacity(self):
-        # This is special-cased as part of update_background_color for discord
-        return
 
     def _setup_webview(self):
         setup_button = QPushButton('\u2699')

--- a/parsers/discord.py
+++ b/parsers/discord.py
@@ -92,8 +92,9 @@ class Discord(ParserWindow):
     _color = ''
     _bg_opacity = 25
 
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self):
+        self.name = "discord"
+        super().__init__()
         QApplication.instance()._signals['settings'].config_updated.connect(self.config_updated)
         self.setAttribute(
             QtCore.Qt.WidgetAttribute.WA_TranslucentBackground, True)

--- a/parsers/maps/window.py
+++ b/parsers/maps/window.py
@@ -22,15 +22,8 @@ class MapsSignals(QObject):
 
 class Maps(ParserWindow):
 
-    _window_opacity = 80
-
-    def __init__(self):
-        super().__init__()
-        QApplication.instance()._signals['settings'].config_updated.connect(self.config_updated)
-        self.name = 'maps'
-        self.setWindowTitle(self.name.title())
-        self.set_title(self.name.title())
-
+    def __init__(self, name):
+        super().__init__(name)
         # interface
         self._map = MapCanvas()
         self.content.addWidget(self._map, 1)
@@ -73,36 +66,8 @@ class Maps(ParserWindow):
             self._map.load_map(config.data['maps']['last_zone'])
         else:
             self._map.load_map('west freeport')
-
-        if config.data.get(self.name, ()).get('auto_hide_menu', True) == False:
-            self.auto_hide_menu = False
-            self._menu.setVisible(True)
-        self.always_on_top = config.data.get(self.name, ()).get('always_on_top', True)
-        self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
-        self.setWindowOpacity(self._window_opacity / 100)
-        self.set_flags()
-        if self.name in config.data.keys() and 'geometry' in config.data[self.name].keys():
-            g = config.data[self.name]['geometry']
-            self.setGeometry(g[0], g[1], g[2], g[3])
         if config.data[self.name]['toggled']:
             self.show()
-
-    def config_updated(self):
-        if self._window_opacity != config.data.get(self.name, {}).get('opacity', 80):
-            self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
-            self.setWindowOpacity(self._window_opacity / 100)
-
-        if self.always_on_top != config.data.get(self.name, ()).get('always_on_top', False):
-            self.always_on_top = config.data.get(self.name, ()).get('always_on_top', False)
-            self.set_flags()
-            if config.data.get(self.name, {}).get('toggled', True):
-                self.show()
-
-        if config.data.get(self.name, ()).get('auto_hide_menu', True) == False:
-            self.auto_hide_menu = False
-            self._menu.setVisible(True)
-        else:
-            self._menu.setVisible(False)
 
     def parse(self, timestamp, text):
         if text[:23] == 'LOADING, PLEASE WAIT...':

--- a/parsers/maps/window.py
+++ b/parsers/maps/window.py
@@ -22,8 +22,9 @@ class MapsSignals(QObject):
 
 class Maps(ParserWindow):
 
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self):
+        self.name = "maps"
+        super().__init__()
         # interface
         self._map = MapCanvas()
         self.content.addWidget(self._map, 1)

--- a/parsers/spells.py
+++ b/parsers/spells.py
@@ -14,8 +14,9 @@ from helpers import ParserWindow, config, format_time, text_time_to_seconds
 class Spells(ParserWindow):
     """Tracks spell casting, duration, and targets by name."""
 
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self):
+        self.name = "spells"
+        super().__init__()
         QApplication.instance()._signals['settings'].spell_triggers_updated.connect(self.load_custom_timers)
         self._setup_ui()
         self.spell_book, self.text_you, self.text_other = create_spell_book()

--- a/parsers/spells.py
+++ b/parsers/spells.py
@@ -14,33 +14,10 @@ from helpers import ParserWindow, config, format_time, text_time_to_seconds
 class Spells(ParserWindow):
     """Tracks spell casting, duration, and targets by name."""
 
-    _window_opacity = 80
-
-    def __init__(self):
-        super().__init__()
-        QApplication.instance()._signals['settings'].config_updated.connect(self.config_updated)
+    def __init__(self, name):
+        super().__init__(name)
         QApplication.instance()._signals['settings'].spell_triggers_updated.connect(self.load_custom_timers)
-        self.name = 'spells'
-        self.setWindowTitle(self.name.title())
-        self.set_title(self.name.title())
-
-        self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
-        self.setWindowOpacity(self._window_opacity / 100)
-        if config.data.get(self.name, ()).get('auto_hide_menu', True) == False:
-            self.auto_hide_menu = False
-            self._menu.setVisible(True)
-        self.always_on_top = config.data.get(self.name, ()).get('always_on_top', True)
-        self.set_flags()
-        if self.name in config.data.keys() and 'geometry' in config.data[self.name].keys():
-            g = config.data[self.name]['geometry']
-            self.setGeometry(g[0], g[1], g[2], g[3])
-        if config.data[self.name]['toggled']:
-            self.show()
-
-
-
         self._setup_ui()
-
         self.spell_book, self.text_you, self.text_other = create_spell_book()
         self._custom_timers = {}  # regex : CustomTimer
         self.load_custom_timers()
@@ -48,24 +25,8 @@ class Spells(ParserWindow):
         self._zoning = None  # holds time of zone or None
         self._spell_triggers = []  # need a queue because of landing windows
         self._spell_trigger = None
-
-
-    def config_updated(self):
-        if self._window_opacity != config.data.get(self.name, {}).get('opacity', 80):
-            self._window_opacity = config.data.get(self.name, {}).get('opacity', 80)
-            self.setWindowOpacity(self._window_opacity / 100)
-
-        if self.always_on_top != config.data.get(self.name, ()).get('always_on_top', False):
-            self.always_on_top = config.data.get(self.name, ()).get('always_on_top', False)
-            self.set_flags()
-            if config.data.get(self.name, {}).get('toggled', True):
-                self.show()
-
-        if config.data.get(self.name, ()).get('auto_hide_menu', True) == False:
-            self.auto_hide_menu = False
-            self._menu.setVisible(True)
-        else:
-            self._menu.setVisible(False)
+        if config.data[self.name]['toggled']:
+            self.show()
 
     def _setup_ui(self):
         self.setMinimumWidth(150)


### PR DESCRIPTION
Refactored the base ParserWindow class.

Changed the base class from a QFrame to a QWidget. We were not using anything that QFrame required. I think this will also make testing easier as well.

Added a "name" var to be required when instantiating ParserWindow. This allowed us to move the logic for autohide/clickthrough/always on top into the parser window instead of the consumers of the class.

Added a config entry for frameless (not visible to the user) which now gets triggered when the windows goes framed/frameless. Reworked logic for this as a result which cleaned up a few window display issues. Mainly where if you closed a window via the taskbar or using the X on the window frame, then re opened.

Hooked up the "window_flush" config setting to now update on settings change instead of application restart.

Removed the need for some function calls and removed others that were not being used ever.

Renamed all internal class methods to be _underscore named