### PR TITLE
Update to nparse.py to fix the way we pass the EQDir to the logreader

### DIFF
--- a/nparse.py
+++ b/nparse.py
@@ -109,7 +109,7 @@ class NomnsParse(QApplication):
 
             else:
                 self._log_reader = logreader.LogReader(
-                    config.data['general']['eq_log_dir'])
+                    os.path.abspath(config.data['general']['eq_log_dir']))
                 QApplication.instance()._signals["logreader"].new_line.connect(self._parse)
                 self._toggled = True
         else:


### PR DESCRIPTION
Updated the var we pass to logreder on init to wrap the config value with os.path.abspath. Previously the logreader glob was getting strings like: "D:/Everquest P1999/Logs\\eqlog_Charactername_project1999.txt" and now it gets strings like: "D:\\Everquest P1999\\Logs\\eqlog_Charactername_project1999.txt".