### PR TITLE
Fix for leaky waypoints and empty playernames

### DIFF
--- a/location_server.py
+++ b/location_server.py
@@ -60,9 +60,9 @@ def clean_old_waypoints():
             for waypoint in list(WAYPOINT_LOCS[group_key][zone]):
                 if now > waypoint[1]:
                     WAYPOINT_LOCS[group_key][zone].pop(waypoint)
-                    if len(WAYPOINT_LOCS[group_key][zone]) == 0:
+                    if not WAYPOINT_LOCS[group_key][zone]:
                         WAYPOINT_LOCS[group_key].pop(zone)
-        if len(WAYPOINT_LOCS[group_key]) == 0:
+        if not WAYPOINT_LOCS[group_key]:
             WAYPOINT_LOCS.pop(group_key)
 
 
@@ -153,9 +153,9 @@ async def remove_player_from_zones(name, group_key, except_zone=None):
             continue
         if name in PLAYER_LOCS[group_key][zone]:
             PLAYER_LOCS[group_key][zone].pop(name)
-            if len(PLAYER_LOCS[group_key][zone]) == 0:
+            if not PLAYER_LOCS[group_key][zone]:
                 PLAYER_LOCS[group_key].pop(zone)
-                if len(PLAYER_LOCS[group_key]) == 0:
+                if not PLAYER_LOCS[group_key]:
                     PLAYER_LOCS.pop(group_key)
 
 

--- a/location_server.py
+++ b/location_server.py
@@ -55,11 +55,15 @@ def users_event():
 
 def clean_old_waypoints():
     now = datetime.datetime.now().timestamp()
-    for group_key in WAYPOINT_LOCS:
-        for zone in WAYPOINT_LOCS[group_key]:
+    for group_key in list(WAYPOINT_LOCS):
+        for zone in list(WAYPOINT_LOCS[group_key]):
             for waypoint in list(WAYPOINT_LOCS[group_key][zone]):
                 if now > waypoint[1]:
                     WAYPOINT_LOCS[group_key][zone].pop(waypoint)
+                    if len(WAYPOINT_LOCS[group_key][zone]) == 0:
+                        WAYPOINT_LOCS[group_key].pop(zone)
+        if len(WAYPOINT_LOCS[group_key]) == 0:
+            WAYPOINT_LOCS.pop(group_key)
 
 
 async def notify_location(websocket, group_key):
@@ -98,7 +102,7 @@ async def register(websocket, player_name=None, group_key=None):
 
 async def unregister(websocket):
     player_name, group_key = PLAYERS.pop(websocket)
-    if player_name:
+    if player_name or player_name == "":
         await remove_player_from_zones(player_name, group_key)
     logging.warning("Deregistering player: %s" % websocket.remote_address[0])
     # await notify_users(websocket)


### PR DESCRIPTION
The change in clean_old_waypoints should address most of your data leakage issues. Any waypoints that were created were cleaned up, but the zones never got cleaned up, leading to the json emitted on every message to grow any time a new zone got a waypoint for the first time. Added logic to cleanup the waypoints based on the remove player logic.

Also while discovering/fixing this issue, I noticed if you used a blank character name for emitting data that the data would not pass the disconnect if player check, so I updated it to check if the player string was empty as well since the if statement was failing on an empty string. Prior to the fix, the player's data was left in the zone after disconnect and was never cleaned up as well.