### PR TITLE
Move self.show() in app init's to parser window base class init.

### DIFF
--- a/helpers/parser.py
+++ b/helpers/parser.py
@@ -21,6 +21,7 @@ class ParserWindow(QWidget):
     _menu_content = None
     _parser_menu_area = None
     _title = None
+    _toggled = False
     _window_flush = None
     _window_opacity = 80
 
@@ -39,6 +40,7 @@ class ParserWindow(QWidget):
         self._clickthrough = config.data.get(self.name, {}).get("clickthrough", True)
         self._frameless = config.data.get(self.name, {}).get("frameless", True)
         self._geometry = config.data.get(self.name, {}).get("geometry", [0,0,200,400])
+        self._toggled = config.data.get(self.name, {}).get("toggled", True)
         self._window_flush = config.data.get("general", {}).get("window_flush", True)
         self._window_opacity = config.data.get(self.name, {}).get("opacity", 80)
 
@@ -89,6 +91,8 @@ class ParserWindow(QWidget):
             self._parser_settings_config_update_watcher
         )
         QApplication.instance().aboutToQuit.connect(self._save_geometry)
+        if self._toggled:
+            self.show()
 
     def _parser_settings_config_update_watcher(self):
         requies_redraw = False

--- a/parsers/discord.py
+++ b/parsers/discord.py
@@ -108,8 +108,6 @@ class Discord(ParserWindow):
         self._bg_opacity = config.data.get(self.name, {}).get('bg_opacity', '25')
 
         self.update_background_color()
-        if config.data[self.name]['toggled']:
-            self.show()
 
     def config_updated(self):
         if self._color != config.data.get(self.name, {}).get('color', '#000000'):

--- a/parsers/maps/window.py
+++ b/parsers/maps/window.py
@@ -67,8 +67,6 @@ class Maps(ParserWindow):
             self._map.load_map(config.data['maps']['last_zone'])
         else:
             self._map.load_map('west freeport')
-        if config.data[self.name]['toggled']:
-            self.show()
 
     def parse(self, timestamp, text):
         if text[:23] == 'LOADING, PLEASE WAIT...':

--- a/parsers/spells.py
+++ b/parsers/spells.py
@@ -26,8 +26,6 @@ class Spells(ParserWindow):
         self._zoning = None  # holds time of zone or None
         self._spell_triggers = []  # need a queue because of landing windows
         self._spell_trigger = None
-        if config.data[self.name]['toggled']:
-            self.show()
 
     def _setup_ui(self):
         self.setMinimumWidth(150)


### PR DESCRIPTION
This moves the toggled behavior out of the individual windows and to the parserwindow base subclass.