### PR TITLE
Fixed parserwindow import

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -7,9 +7,6 @@ import json
 
 import semver
 
-from .parser import ParserWindow  # noqa: F401
-
-
 def get_version():
     version = None
     try:

--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -1,4 +1,4 @@
 
-from .maps import Maps  # noqa: F401
-from .spells import Spells  # noqa: F401
-from .discord import Discord  # noqa: F401
+from .maps import Maps
+from .spells import Spells
+from .discord import Discord

--- a/parsers/discord.py
+++ b/parsers/discord.py
@@ -5,7 +5,8 @@ from PySide6.QtGui import QColor
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import QApplication, QScrollArea, QPushButton, QDialog, QGridLayout
 
-from helpers import ParserWindow, config
+from helpers.parser import ParserWindow
+from helpers import config
 
 
 JS_ADD_CSS_TEMPLATE = """(

--- a/parsers/maps/__init__.py
+++ b/parsers/maps/__init__.py
@@ -1,2 +1,2 @@
-from .window import Maps  # noqa: F401
-from .mapdata import MapData  # noqa: F401
+from .window import Maps
+from .mapdata import MapData

--- a/parsers/maps/window.py
+++ b/parsers/maps/window.py
@@ -4,7 +4,8 @@ import re
 from PySide6.QtCore import Signal, QObject
 from PySide6.QtWidgets import QHBoxLayout, QPushButton, QApplication
 
-from helpers import config, to_real_xy, ParserWindow
+from helpers.parser import ParserWindow
+from helpers import config, to_real_xy
 from .mapcanvas import MapCanvas
 from .mapclasses import MapPoint
 from .mapdata import MapData

--- a/parsers/spells.py
+++ b/parsers/spells.py
@@ -8,7 +8,8 @@ from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (QApplication, QFrame, QHBoxLayout, QLabel, QProgressBar,
                              QScrollArea, QSpinBox, QVBoxLayout, QPushButton)
 
-from helpers import ParserWindow, config, format_time, text_time_to_seconds
+from helpers.parser import ParserWindow
+from helpers import config, format_time, text_time_to_seconds
 
 
 class Spells(ParserWindow):


### PR DESCRIPTION
Found an issue where the helpers __init__.py was calling ParserWindow and then other windows were loading ParserWindow from there instead of loading it directly.

Updated the other windows to import ParserWindow from its correct location which i believe will resolve the flake8 overrides you guys had as well which were related to unused imports which was the case for helpers __init__.py since it imported but never used ParserWindow and other things imported off it.